### PR TITLE
Close APN::Feedback connection after receiving tokens

### DIFF
--- a/lib/pling/apn/feedback.rb
+++ b/lib/pling/apn/feedback.rb
@@ -25,14 +25,14 @@ module Pling
       
       ##
       # Creates a new instance of this class and establishes a connection to
-      # Apple's Push Notification Service.
+      # Apple's Push Notification Service, retrieves a list of invalid device
+      # identifiers and then closes the connection, since Apple closes it on
+      # their side.
       # 
-      # The connection is only established once since Apple will ban you if
-      # you reconnect each time you want to retrieve the list of invalid
-      # device identifiers. For testing purposes, you should use Apple's
-      # sandbox feedback service +feedback.sandbox.push.apple.com+. In order
-      # to do this, you have to specify the optional +:host+ parameter when
-      # creating instances of this class.
+      # For testing purposes, you should use Apple's sandbox feedback service
+      # +feedback.sandbox.push.apple.com+. In order to do this, you have to
+      # specify the optional +:host+ parameter when creating instances of this
+      # class.
       #
       # @param [Hash] configuration Parameters to control the connection configuration
       # @option configuration [#to_s] :certificate Path to PEM certificate file (Required)
@@ -63,6 +63,7 @@ module Pling
           time, length = line.unpack("Nn")
           tokens << line.unpack("x6H#{length << 1}").first
         end
+        connection.close
         tokens
       end
 

--- a/spec/pling/apn/feedback_spec.rb
+++ b/spec/pling/apn/feedback_spec.rb
@@ -38,6 +38,12 @@ describe Pling::APN::Feedback do
       
       tokens.should be == [token_0, token_1]
     end
+
+    it "closes the connection after receiving all tokens" do
+      connection.should_receive(:close)
+
+      subject.get
+    end
     
   end
 


### PR DESCRIPTION
After retrieving all invalid device identifiers from Apple via `APN::Feedback#get`, Apple closes the connection and the socket stays opened in a `CLOSE_WAIT` state and gets not cleaned up and closed.

This PR fixes this by closing the connection after receiving all identifiers, enabling the socket to be cleaned up, which frees up resources.

For more information, see the [Apple Documentation about their Feedback Service](http://developer.apple.com/library/mac/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/Chapters/CommunicatingWIthAPS.html#//apple_ref/doc/uid/TP40008194-CH101-SW3)

The documentation does not describe that opening a connection to the Feedback Service on a regular basis will result in a ban. It rather says the opposite: you should reopen the connection on a regular basis to retrieve new tokens.

And since Apple closes the connection, I think it's a good idea to close the connection too, to free up resources.

Thoughts?
