### PR TITLE
Relaxes the connection pool dependency version requirement

### DIFF
--- a/pling.gemspec
+++ b/pling.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "faraday", "~> 0.7"
   s.add_runtime_dependency "faraday_middleware", "~> 0.8"
   s.add_runtime_dependency "json", "~> 1.4"
-  s.add_runtime_dependency "connection_pool", "~> 2.0.0"
+  s.add_runtime_dependency "connection_pool", "~> 2.0"
   s.add_runtime_dependency("jruby-openssl") if RUBY_PLATFORM == 'java'
 
   s.add_development_dependency "rspec", "~> 2.7"


### PR DESCRIPTION
Looking the connection_pool gem to 2.0.x causes problems with the current version of Sidekiq, which needs at least connection_pool 2.2.x. This pull request relaxes the version requirement a bit.