### PR TITLE
Make content-available flag available for APN

### DIFF
--- a/lib/pling/apn/gateway.rb
+++ b/lib/pling/apn/gateway.rb
@@ -50,10 +50,11 @@ module Pling
           :aps => {
             :alert => message.body,
             :badge => message.badge && message.badge.to_i,
-            :sound => message.sound
+            :sound => message.sound,
           }.delete_if { |_, value| value.nil? }
         }
 
+        data[:aps]['content-available'] = 1 if message.content_available
         data.merge!(message.payload) if configuration[:payload] && message.payload
 
         data = data.to_json

--- a/lib/pling/message.rb
+++ b/lib/pling/message.rb
@@ -66,6 +66,18 @@ module Pling
     end
 
     ##
+    # The content_available property - not supported by all gateways
+    #
+    # @overload content_available
+    # @overload content_available=()
+    attr_reader :content_available
+
+    def content_available=(content_available)
+      content_available &&= !!content_available
+      @content_available = content_available
+    end
+
+    ##
     # Creates a new Pling::Message instance with the given body
     #
     # @overload initialize(body)

--- a/spec/pling/apn/gateway_spec.rb
+++ b/spec/pling/apn/gateway_spec.rb
@@ -118,6 +118,23 @@ describe Pling::APN::Gateway do
       subject.deliver(message, device)
     end
 
+    it 'should include the given content_available flag' do
+      expected_payload = {
+        'aps' => {
+          'alert' => 'Hello from Pling',
+          'content-available' => 1
+        }
+      }
+
+      connection.stub(:write) do |packet|
+        JSON.parse(packet[37..-1]).should eq(expected_payload)
+      end
+
+      message.content_available = 1
+
+      subject.deliver(message, device)
+    end
+
     context 'when configured to include payload' do
       before do
         valid_configuration.merge!(:payload => true)

--- a/spec/pling/message_spec.rb
+++ b/spec/pling/message_spec.rb
@@ -47,6 +47,16 @@ describe Pling::Message do
     its(:payload) { should eq({ :data => true }) }
   end
 
+  context 'when created with a hash that contains a :content_available key' do
+    subject { Pling::Message.new(:content_available => true)}
+    its(:content_available) { should eq(true) }
+
+    context 'when the key is not present' do
+      subject { Pling::Message.new }
+      its(:content_available) { should eq(nil) }
+    end
+  end
+
   context 'when created with an hash of invalid attributes' do
     it 'should ignore the invalid paramters' do
       expect { Pling::Message.new({ :random_param => true }) }.to_not raise_error


### PR DESCRIPTION
This extends the `Pling::Message` class so it has a `content_available` property in order to send this property as `content-available` to APN.

According to the [documentation](https://developer.apple.com/library/ios/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/Chapters/ApplePushService.html#//apple_ref/doc/uid/TP40008194-CH100-SW9) this value is an integer that's either set to `1` or not, depending on whether there is content available or not.

Per default the value is `nil` and thus not sent to APN.

It also extends the `APN::Gateway` so that it sends the `content-available` flag to APN.