### PR TITLE
Make category attribute available for APN messages

### DIFF
--- a/lib/pling/apn/gateway.rb
+++ b/lib/pling/apn/gateway.rb
@@ -55,6 +55,7 @@ module Pling
         }
 
         data[:aps]['content-available'] = 1 if message.content_available
+        data[:aps]['category'] = message.category if message.category
         data.merge!(message.payload) if configuration[:payload] && message.payload
 
         data = data.to_json

--- a/lib/pling/message.rb
+++ b/lib/pling/message.rb
@@ -78,6 +78,18 @@ module Pling
     end
 
     ##
+    # The category property - not supported by all gateways
+    #
+    # @overload category
+    # @overload category=()
+    attr_reader :category
+
+    def category=(category)
+      category &&= category.to_s
+      @category = category
+    end
+
+    ##
     # Creates a new Pling::Message instance with the given body
     #
     # @overload initialize(body)

--- a/spec/pling/apn/gateway_spec.rb
+++ b/spec/pling/apn/gateway_spec.rb
@@ -135,6 +135,23 @@ describe Pling::APN::Gateway do
       subject.deliver(message, device)
     end
 
+    it 'should include the given category' do
+      expected_payload = {
+        'aps' => {
+          'alert' => 'Hello from Pling',
+          'category' => 'foobar'
+        }
+      }
+
+      connection.stub(:write) do |packet|
+        JSON.parse(packet[37..-1]).should eq(expected_payload)
+      end
+
+      message.category = 'foobar'
+
+      subject.deliver(message, device)
+    end
+
     context 'when configured to include payload' do
       before do
         valid_configuration.merge!(:payload => true)

--- a/spec/pling/message_spec.rb
+++ b/spec/pling/message_spec.rb
@@ -57,6 +57,22 @@ describe Pling::Message do
     end
   end
 
+  context 'when created with a hash that contains a :category key' do
+    subject { Pling::Message.new(:category => 'foobar')}
+    its(:category) { should eq('foobar') }
+
+    context 'when the value behind the :category key is not a string' do
+      subject { Pling::Message.new(:category => :foobar)}
+
+      its(:category) { should eq('foobar') }
+    end
+
+    context 'when the key is not present' do
+      subject { Pling::Message.new }
+      its(:category) { should eq(nil) }
+    end
+  end
+
   context 'when created with an hash of invalid attributes' do
     it 'should ignore the invalid paramters' do
       expect { Pling::Message.new({ :random_param => true }) }.to_not raise_error


### PR DESCRIPTION
This extends `Pling::Message` to have a `category` property. When setting the `category` it always gets converted to a string. If not set, it's `nil`.

`APN::Gateway` then checks whether `category` is set (truthy) and adds it to the `aps` hash of the message.

According to the [Apple documentation](https://developer.apple.com/library/ios/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/Chapters/ApplePushService.html#//apple_ref/doc/uid/TP40008194-CH100-SW1) the category has to correspond to a custom value defined in the receiving application and should be a string.

If the category is not set, we do not try to send it to Apple, to keep the default behaviour.