### PR TITLE
Update RSpec to 3.3 and get rid of the deprecation warnings

### DIFF
--- a/pling.gemspec
+++ b/pling.gemspec
@@ -22,7 +22,8 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "connection_pool", "~> 2.0"
   s.add_runtime_dependency("jruby-openssl") if RUBY_PLATFORM == 'java'
 
-  s.add_development_dependency "rspec", "~> 2.7"
+  s.add_development_dependency "rspec", "~> 3.3"
+  s.add_development_dependency "rspec-its", ">= 1.2"
   s.add_development_dependency "yard", ">= 0.7"
   s.add_development_dependency "rake", ">= 0.9"
 end

--- a/spec/pling/adapter/base_spec.rb
+++ b/spec/pling/adapter/base_spec.rb
@@ -6,7 +6,7 @@ describe Pling::Adapter::Base do
 
     let(:device)  { Pling::Device.new }
     let(:message) { Pling::Message.new }
-    let(:gateway) { mock(:deliver => true) }
+    let(:gateway) { double(:gateway_double, :deliver => true) }
 
     it 'should try to discover a gateway' do
       Pling::Gateway.should_receive(:discover).with(device).and_return(gateway)

--- a/spec/pling/apn/gateway_spec.rb
+++ b/spec/pling/apn/gateway_spec.rb
@@ -37,11 +37,11 @@ describe Pling::APN::Gateway do
     subject { Pling::APN::Gateway.new(valid_configuration) }
 
     it 'should raise an error if no message is given' do
-      expect { subject.deliver(nil, device) }.to raise_error
+      expect { subject.deliver(nil, device) }.to raise_error(ArgumentError, /do not implement #to_pling_message/)
     end
 
     it 'should raise an error the device is given' do
-      expect { subject.deliver(message, nil) }.to raise_error
+      expect { subject.deliver(message, nil) }.to raise_error(ArgumentError, /do not implement #to_pling_device/)
     end
 
     it 'should initialize a new APN connection if none is established' do

--- a/spec/pling/c2dm/gateway_spec.rb
+++ b/spec/pling/c2dm/gateway_spec.rb
@@ -6,27 +6,27 @@ describe Pling::C2DM::Gateway do
     { :email => 'someone@gmail.com', :password => 'random', :source => 'some-source' }
   end
 
-  let(:authentication_response_mock) do
-    mock('Faraday authentication response', :success? => true, :status => 200, :body => "SID=SOMESID\nAuth=S0ME-ToKeN123")
+  let(:authentication_response_double) do
+    double(:authentication_response_double, :success? => true, :status => 200, :body => "SID=SOMESID\nAuth=S0ME-ToKeN123")
   end
 
-  let(:push_response_mock) do
-    mock('Faraday send response', :success? => true, :status => 200, :body => "")
+  let(:push_response_double) do
+    double(:push_response_double, :success? => true, :status => 200, :body => "")
   end
 
-  let(:connection_mock) do
-    mock('Faraday connection').tap do |mock|
-      mock.stub(:post).
+  let(:connection_double) do
+    double(:connection_double).tap do |connection|
+      connection.stub(:post).
         with('https://www.google.com/accounts/ClientLogin', anything).
-        and_return(authentication_response_mock)
+        and_return(authentication_response_double)
 
-      mock.stub(:post).
+      connection.stub(:post).
         with('https://android.apis.google.com/c2dm/send', anything, anything).
-        and_return(push_response_mock)
+        and_return(push_response_double)
     end
   end
 
-  before { Faraday.stub(:new).and_return(connection_mock) }
+  before { Faraday.stub(:new).and_return(connection_double) }
 
   it 'should handle various apn related device types' do
     Pling::C2DM::Gateway.handled_types.should =~ [:android, :c2dm]
@@ -60,9 +60,9 @@ describe Pling::C2DM::Gateway do
       end
 
       it 'should try to authenticate' do
-        connection_mock.should_receive(:post).
+        connection_double.should_receive(:post).
           with('https://www.google.com/accounts/ClientLogin', valid_authentication_params).
-          and_return(authentication_response_mock)
+          and_return(authentication_response_double)
 
         Pling::C2DM::Gateway.new(valid_configuration)
       end
@@ -73,13 +73,13 @@ describe Pling::C2DM::Gateway do
       end
 
       it 'should raise an error if authentication was not successful' do
-        authentication_response_mock.stub(:status => 403, :success? => false, :body => 'Error=BadAuthentication')
+        authentication_response_double.stub(:status => 403, :success? => false, :body => 'Error=BadAuthentication')
 
         expect { Pling::C2DM::Gateway.new(valid_configuration) }.to raise_error(Pling::AuthenticationFailed, /Authentication failed: \[403\] Error=BadAuthentication/)
       end
 
       it 'should raise an error if it could not extract a token from the response' do
-        authentication_response_mock.stub(:body).and_return('SOMERANDOMBODY')
+        authentication_response_double.stub(:body).and_return('SOMERANDOMBODY')
 
         expect { Pling::C2DM::Gateway.new(valid_configuration) }.to raise_error(Pling::AuthenticationFailed, /Token extraction failed/)
       end
@@ -92,25 +92,25 @@ describe Pling::C2DM::Gateway do
       end
 
       it 'should use Faraday::Response::Logger when :debug is set to true' do
-        builder = mock(:use => true, :adapter => true)
+        builder = double(:builder_double, :use => true, :adapter => true)
         builder.should_receive(:use).with(Faraday::Response::Logger)
-        Faraday.stub(:new).and_yield(builder).and_return(connection_mock)
+        Faraday.stub(:new).and_yield(builder).and_return(connection_double)
 
         Pling::C2DM::Gateway.new(valid_configuration.merge(:debug => true))
       end
 
       it 'should use the adapter set with :adapter' do
-        builder = mock(:use => true, :adapter => true)
+        builder = double(:builder_double, :use => true, :adapter => true)
         builder.should_receive(:adapter).with(:typheus)
-        Faraday.stub(:new).and_yield(builder).and_return(connection_mock)
+        Faraday.stub(:new).and_yield(builder).and_return(connection_double)
 
         Pling::C2DM::Gateway.new(valid_configuration.merge(:adapter => :typheus))
       end
 
       it 'should allow configuring the authentication_url' do
-        connection_mock.should_receive(:post).
+        connection_double.should_receive(:post).
           with('http://example.com/authentication', anything).
-          and_return(authentication_response_mock)
+          and_return(authentication_response_double)
 
         Pling::C2DM::Gateway.new(valid_configuration.merge(:authentication_url => 'http://example.com/authentication'))
       end
@@ -156,49 +156,49 @@ describe Pling::C2DM::Gateway do
     end
 
     it 'should try to deliver the given message' do
-      connection_mock.should_receive(:post).
+      connection_double.should_receive(:post).
         with('https://android.apis.google.com/c2dm/send', valid_push_params, valid_push_headers).
-        and_return(push_response_mock)
+        and_return(push_response_double)
 
       subject.deliver(message, device)
     end
 
     it 'should raise a Pling::DeliveryFailed exception if the delivery was not successful' do
-      connection_mock.should_receive(:post).with('https://android.apis.google.com/c2dm/send', anything, anything).
-and_return(push_response_mock)
-      push_response_mock.stub(:status => 401, :success? => false, :body => "Something went wrong")
+      connection_double.should_receive(:post).with('https://android.apis.google.com/c2dm/send', anything, anything).
+        and_return(push_response_double)
+      push_response_double.stub(:status => 401, :success? => false, :body => "Something went wrong")
 
       expect { subject.deliver(message, device) }.to raise_error Pling::DeliveryFailed, /Something went wrong/
     end
 
     it 'should raise a Pling::DeliveryFailed exception if the response body contained an error' do
-      connection_mock.should_receive(:post).with('https://android.apis.google.com/c2dm/send', anything, anything).
-and_return(push_response_mock)
-      push_response_mock.stub(:status => 200, :success? => true, :body => "Error=SomeError")
+      connection_double.should_receive(:post).with('https://android.apis.google.com/c2dm/send', anything, anything).
+        and_return(push_response_double)
+      push_response_double.stub(:status => 200, :success? => true, :body => "Error=SomeError")
 
       expect { subject.deliver(message, device) }.to raise_error Pling::DeliveryFailed, /Error=SomeError/
     end
 
     it 'should send data.badge if the given message has a badge' do
-      connection_mock.should_receive(:post).
+      connection_double.should_receive(:post).
         with(anything, hash_including(:'data.badge' => '10'), anything).
-        and_return(push_response_mock)
+        and_return(push_response_double)
       message.badge = 10
       subject.deliver(message, device)
     end
 
     it 'should send data.sound if the given message has a sound' do
-      connection_mock.should_receive(:post).
+      connection_double.should_receive(:post).
         with(anything, hash_including(:'data.sound' => 'pling'), anything).
-        and_return(push_response_mock)
+        and_return(push_response_double)
       message.sound = :pling
       subject.deliver(message, device)
     end
 
     it 'should send data.subject if the given message has a subject' do
-      connection_mock.should_receive(:post).
+      connection_double.should_receive(:post).
         with(anything, hash_including(:'data.subject' => 'Important!'), anything).
-        and_return(push_response_mock)
+        and_return(push_response_double)
       message.subject = 'Important!'
       subject.deliver(message, device)
     end
@@ -210,9 +210,9 @@ and_return(push_response_mock)
       end
 
       it 'should include the given payload' do
-        connection_mock.should_receive(:post).
+        connection_double.should_receive(:post).
           with(anything, hash_including(:'data.data' => 'available'), anything).
-          and_return(push_response_mock)
+          and_return(push_response_double)
         subject.deliver(message, device)
       end
     end
@@ -224,9 +224,9 @@ and_return(push_response_mock)
       end
 
       it 'should include the given payload' do
-        connection_mock.should_receive(:post).
+        connection_double.should_receive(:post).
           with(anything, hash_not_including(:'data.data' => 'available'), anything).
-          and_return(push_response_mock)
+          and_return(push_response_double)
         subject.deliver(message, device)
       end
     end
@@ -235,7 +235,7 @@ and_return(push_response_mock)
      :InvalidRegistration, :NotRegistered,
      :MessageTooBig, :MissingCollapseKey].each do |exception|
       it "should raise a Pling::C2DM::#{exception} when the response body is ''" do
-        push_response_mock.stub(:body => "Error=#{exception}")
+        push_response_double.stub(:body => "Error=#{exception}")
         expect { subject.deliver(message, device) }.to raise_error Pling::C2DM.const_get(exception)
       end
     end

--- a/spec/pling/c2dm/gateway_spec.rb
+++ b/spec/pling/c2dm/gateway_spec.rb
@@ -138,11 +138,11 @@ describe Pling::C2DM::Gateway do
     end
 
     it 'should raise an error if no message is given' do
-      expect { subject.deliver(nil, device) }.to raise_error
+      expect { subject.deliver(nil, device) }.to raise_error(ArgumentError, /do not implement #to_pling_message/)
     end
 
     it 'should raise an error the device is given' do
-      expect { subject.deliver(message, nil) }.to raise_error
+      expect { subject.deliver(message, nil) }.to raise_error(ArgumentError, /do not implement #to_pling_device/)
     end
 
     it 'should call #to_pling_message on the given message' do

--- a/spec/pling/device_spec.rb
+++ b/spec/pling/device_spec.rb
@@ -4,7 +4,7 @@ describe Pling::Device do
 
   context 'when created with no arguments' do
     it 'should not require an argument' do
-      expect { Pling::Device.new }.to_not raise_error ArgumentError
+      expect { Pling::Device.new }.to_not raise_error
     end
 
     specify { Pling::Device.new.should_not be_valid }

--- a/spec/pling/device_spec.rb
+++ b/spec/pling/device_spec.rb
@@ -41,7 +41,7 @@ describe Pling::Device do
 
   describe '#identifier=' do
     it 'should call #to_s on the given identifier' do
-      subject.identifier = stub(:to_s => 'XXXX')
+      subject.identifier = double(:identifier_double, :to_s => 'XXXX')
       subject.identifier.should eq('XXXX')
     end
   end

--- a/spec/pling/gateway_spec.rb
+++ b/spec/pling/gateway_spec.rb
@@ -24,7 +24,7 @@ describe Pling::Gateway do
   describe '.discover' do
     it 'should do a delayed initialization' do
       Pling.stub(:gateways).and_return(Pling::DelayedInitializer.new([[gateway_class, { :some => :option }]]))
-      gateway_class.should_receive(:new).with({ :some => :option }).and_return(mock.as_null_object)
+      gateway_class.should_receive(:new).with({ :some => :option }).and_return(double.as_null_object)
       subject.discover(device)
     end
 
@@ -50,15 +50,15 @@ describe Pling::Gateway do
   describe '#handles?' do
     it 'should return true if the gateway supports the given device\'s type' do
       device.type = :android
-      gateway.handles?(device).should be_true
+      gateway.handles?(device).should be true
 
       device.type = :c2dm
-      gateway.handles?(device).should be_true
+      gateway.handles?(device).should be true
     end
 
     it 'should return false if the gateway does not support the given device\'s type' do
       device.type = :random
-      gateway.handles?(device).should be_false
+      gateway.handles?(device).should be false
     end
   end
 

--- a/spec/pling/gateway_spec.rb
+++ b/spec/pling/gateway_spec.rb
@@ -98,9 +98,9 @@ describe Pling::Gateway do
     end
 
     it 'should not raise an Pling::Errors if an on_exception callback is set' do
-      gateway = gateway_class.new(:on_exception => lambda {})
+      gateway = gateway_class.new(:on_exception => lambda {|_| })
       gateway.stub(:deliver!).and_raise(Pling::Error)
-      expect { gateway.deliver(message, device) }.to_not raise_error Pling::Error
+      expect { gateway.deliver(message, device) }.to_not raise_error
     end
 
     it 'should pass the exception to the callback' do

--- a/spec/pling/gcm/gateway_spec.rb
+++ b/spec/pling/gcm/gateway_spec.rb
@@ -83,11 +83,11 @@ describe Pling::GCM::Gateway do
     end
 
     it 'should raise an error if no message is given' do
-      expect { subject.deliver(nil, device) }.to raise_error
+      expect { subject.deliver(nil, device) }.to raise_error(ArgumentError, /do not implement #to_pling_message/)
     end
 
     it 'should raise an error the device is given' do
-      expect { subject.deliver(message, nil) }.to raise_error
+      expect { subject.deliver(message, nil) }.to raise_error(ArgumentError, /do not implement #to_pling_device/)
     end
 
     it 'should call #to_pling_message on the given message' do

--- a/spec/pling/gcm/gateway_spec.rb
+++ b/spec/pling/gcm/gateway_spec.rb
@@ -6,15 +6,15 @@ describe Pling::GCM::Gateway do
     { :key => 'some-key' }
   end
 
-  let(:push_response_mock) do
-    mock('Faraday send response', :success? => true, :status => 200, :body => "")
+  let(:push_response_double) do
+    double(:response_double, :success? => true, :status => 200, :body => "")
   end
 
   let(:connection_mock) do
-    mock('Faraday connection').tap do |mock|
-      mock.stub(:post).
+    double(:connection_double).tap do |connection|
+      connection.stub(:post).
         with('https://android.googleapis.com/gcm/send', anything, anything).
-        and_return(push_response_mock)
+        and_return(push_response_double)
     end
   end
 
@@ -47,7 +47,7 @@ describe Pling::GCM::Gateway do
       end
 
       it 'should use Faraday::Response::Logger when :debug is set to true' do
-        builder = mock(:use => true, :adapter => true)
+        builder = double(:builder_double, :use => true, :adapter => true)
         builder.should_receive(:use).with(Faraday::Response::Logger)
         Faraday.stub(:new).and_yield(builder).and_return(connection_mock)
 
@@ -55,7 +55,7 @@ describe Pling::GCM::Gateway do
       end
 
       it 'should use the adapter set with :adapter' do
-        builder = mock(:use => true, :adapter => true)
+        builder = double(:builder_double, :use => true, :adapter => true)
         builder.should_receive(:adapter).with(:typheus)
         Faraday.stub(:new).and_yield(builder).and_return(connection_mock)
 
@@ -103,21 +103,21 @@ describe Pling::GCM::Gateway do
     it 'should try to deliver the given message' do
       connection_mock.should_receive(:post).
         with('https://android.googleapis.com/gcm/send', valid_push_params, valid_push_headers).
-        and_return(push_response_mock)
+        and_return(push_response_double)
 
       subject.deliver(message, device)
     end
 
     it 'should raise a Pling::DeliveryFailed exception if the delivery was not successful' do
-      connection_mock.should_receive(:post).and_return(push_response_mock)
-      push_response_mock.stub(:status => 401, :success? => false, :body => "Something went wrong")
+      connection_mock.should_receive(:post).and_return(push_response_double)
+      push_response_double.stub(:status => 401, :success? => false, :body => "Something went wrong")
 
       expect { subject.deliver(message, device) }.to raise_error Pling::DeliveryFailed, /Something went wrong/
     end
 
     it 'should raise a Pling::DeliveryFailed exception if the response body contained an error' do
-      connection_mock.should_receive(:post).and_return(push_response_mock)
-      push_response_mock.stub(:status => 200, :success? => true, :body => { 'failure' => 1, 'results' => ['error' => 'SomeError'] })
+      connection_mock.should_receive(:post).and_return(push_response_double)
+      push_response_double.stub(:status => 200, :success? => true, :body => { 'failure' => 1, 'results' => ['error' => 'SomeError'] })
 
       expect { subject.deliver(message, device) }.to raise_error Pling::DeliveryFailed, /SomeError/
     end
@@ -125,7 +125,7 @@ describe Pling::GCM::Gateway do
     it 'should send data.badge if the given message has a badge' do
       connection_mock.should_receive(:post).
         with(anything, hash_including(:data => hash_including({ :badge => '10' })), anything).
-        and_return(push_response_mock)
+        and_return(push_response_double)
       message.badge = 10
       subject.deliver(message, device)
     end
@@ -133,7 +133,7 @@ describe Pling::GCM::Gateway do
     it 'should send data.sound if the given message has a sound' do
       connection_mock.should_receive(:post).
         with(anything, hash_including(:data => hash_including({ :sound => 'pling' })), anything).
-        and_return(push_response_mock)
+        and_return(push_response_double)
       message.sound = :pling
       subject.deliver(message, device)
     end
@@ -141,7 +141,7 @@ describe Pling::GCM::Gateway do
     it 'should send data.subject if the given message has a subject' do
       connection_mock.should_receive(:post).
         with(anything, hash_including(:data => hash_including({ :subject => 'Important!' })), anything).
-        and_return(push_response_mock)
+        and_return(push_response_double)
       message.subject = 'Important!'
       subject.deliver(message, device)
     end
@@ -155,7 +155,7 @@ describe Pling::GCM::Gateway do
       it 'should include the given payload' do
         connection_mock.should_receive(:post).
           with(anything, hash_including(:data => hash_including({ :data => 'available' })), anything).
-          and_return(push_response_mock)
+          and_return(push_response_double)
         subject.deliver(message, device)
       end
     end
@@ -169,7 +169,7 @@ describe Pling::GCM::Gateway do
       it 'should include the given payload' do
         connection_mock.should_receive(:post).
           with(anything, hash_not_including(:'data.data' => 'available'), anything).
-          and_return(push_response_mock)
+          and_return(push_response_double)
         subject.deliver(message, device)
       end
     end
@@ -178,7 +178,7 @@ describe Pling::GCM::Gateway do
      :NotRegistered, :MessageTooBig, :InvalidTtl, :Unavailable,
      :InternalServerError].each do |exception|
       it "should raise a Pling::GCM::#{exception} when the response body is ''" do
-        push_response_mock.stub(:body => { 'failure' => 1, 'results' => [{ 'error' => exception }]})
+        push_response_double.stub(:body => { 'failure' => 1, 'results' => [{ 'error' => exception }]})
         expect { subject.deliver(message, device) }.to raise_error Pling::GCM.const_get(exception)
       end
     end

--- a/spec/pling/message_spec.rb
+++ b/spec/pling/message_spec.rb
@@ -65,7 +65,7 @@ describe Pling::Message do
 
   describe '#body=' do
     it 'should call #to_s on the given body' do
-      subject.body = stub(:to_s => 'Hello from Pling')
+      subject.body = double(:body_double, :to_s => 'Hello from Pling')
       subject.body.should eq('Hello from Pling')
     end
   end

--- a/spec/pling/message_spec.rb
+++ b/spec/pling/message_spec.rb
@@ -4,7 +4,7 @@ describe Pling::Message do
 
   context 'when created with no arguments' do
     it 'should not require an argument' do
-      expect { Pling::Message.new() }.to_not raise_error ArgumentError
+      expect { Pling::Message.new() }.to_not raise_error
     end
 
     specify { Pling::Message.new().should_not be_valid }

--- a/spec/pling_spec.rb
+++ b/spec/pling_spec.rb
@@ -59,7 +59,7 @@ describe Pling do
 
     let(:message) { Pling::Message.new }
     let(:device)  { Pling::Device.new  }
-    let(:adapter) { mock(:deliver => true) }
+    let(:adapter) { double(:adapter_double, :deliver => true) }
 
     before do
       Pling.stub(:adapter).and_return(adapter)

--- a/spec/pling_spec.rb
+++ b/spec/pling_spec.rb
@@ -66,11 +66,11 @@ describe Pling do
     end
 
     it 'should raise an error if no message is given' do
-      expect { Pling.deliver(nil, device) }.to raise_error
+      expect { Pling.deliver(nil, device) }.to raise_error(ArgumentError, /do not implement #to_pling_message/)
     end
 
     it 'should raise an error the device is given' do
-      expect { Pling.deliver(message, nil) }.to raise_error
+      expect { Pling.deliver(message, nil) }.to raise_error(ArgumentError, /do not implement #to_pling_device/)
     end
 
     it 'should call #to_pling_message on the given message' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 require 'rubygems'
 require 'bundler'
 
+require 'rspec/its'
 Bundler.require
 
 Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,5 +7,11 @@ Bundler.require
 Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }
 
 RSpec.configure do |config|
-  config.mock_with :rspec
+  config.mock_with :rspec do |mocks|
+    mocks.syntax = [:should, :expect]
+  end
+
+  config.expect_with :rspec do |expectations|
+    expectations.syntax = [:should, :expect]
+  end
 end


### PR DESCRIPTION
Updates RSpec but keeps the `should` syntax for now. Every other deprecation and failing test is fixed now.