### PR TITLE
Fix nil-error when APN returns no tokens

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,6 @@ sudo: false
 language: ruby
 rvm:
   - ruby-head
-  - 2.2.3
-  - 2.1.7
+  - 2.3.1
+  - 2.2.5
   - jruby

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,4 @@ source 'http://rubygems.org'
 # Specify your gem's dependencies in pling.gemspec
 gemspec
 
-gem 'guard'
-gem 'guard-rspec'
-gem 'guard-yard', :platform => :ruby_19
 gem 'rdiscount', ">= 1.6.8", :platform => :ruby

--- a/lib/pling/apn/feedback.rb
+++ b/lib/pling/apn/feedback.rb
@@ -60,7 +60,9 @@ module Pling
       def get
         tokens = []
         while line = connection.gets
-          time, length = line.unpack("Nn")
+          _, length = line.unpack("Nn")
+          break if length.nil?
+
           tokens << line.unpack("x6H#{length << 1}").first
         end
         connection.close

--- a/spec/pling/apn/feedback_spec.rb
+++ b/spec/pling/apn/feedback_spec.rb
@@ -44,7 +44,15 @@ describe Pling::APN::Feedback do
 
       subject.get
     end
-    
-  end
 
+    context 'when the feedback results in no packed data' do
+      before { connection.stub(:gets).and_return('') }
+
+      it 'returns an empty array' do
+        tokens = subject.get
+
+        tokens.should eq([])
+      end
+    end
+  end
 end


### PR DESCRIPTION
This error was caught in the wild and happens when APN doesn't return any data, but just "data" that results in `length` being `nil`.

This adds a test case that reproduces the error and fixes it by stopping the fetching of data as soon as `nil` is encountered.

Also: an unused local variable is removed by replacing it with the `_`.
